### PR TITLE
Add canonical URL support and update Astro configuration

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,6 +5,7 @@ import { ASTRO_DEFAULT_LOCALE, ASTRO_I18N_LOCALES } from "./src/i18n/config";
 
 // https://astro.build/config
 export default defineConfig({
+  trailingSlash: "never",
   env: {
     schema: {
       FLOTIQ_API_KEY: envField.string({

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,10 +1,17 @@
 ---
+import { canonicalPathname } from "../lib/canonicalUrl";
+
 interface Props {
   lang?: string;
   title?: string;
 }
 
 const { lang = "en", title = "Site" } = Astro.props;
+
+const canonicalHref =
+  Astro.site != null
+    ? new URL(canonicalPathname(Astro.url.pathname), Astro.site).href
+    : undefined;
 ---
 
 <!doctype html>
@@ -15,6 +22,7 @@ const { lang = "en", title = "Site" } = Astro.props;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="generator" content={Astro.generator} />
+    {canonicalHref ? <link rel="canonical" href={canonicalHref} /> : null}
     <title>{title}</title>
   </head>
   <body>

--- a/src/lib/canonicalUrl.ts
+++ b/src/lib/canonicalUrl.ts
@@ -1,0 +1,7 @@
+/** Match `trailingSlash: 'never'` in astro.config.ts */
+export function canonicalPathname(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getRelativeLocaleUrl } from "astro:i18n";
 import Layout from "../layouts/Layout.astro";
 import { LOCALES, localePathSegment } from "../i18n/config";
 ---
@@ -9,7 +10,9 @@ import { LOCALES, localePathSegment } from "../i18n/config";
       {
         LOCALES.map((loc) => (
           <li>
-            <a href={`/${localePathSegment(loc.code)}/`}>{loc.label}</a>
+            <a href={getRelativeLocaleUrl(localePathSegment(loc.code))}>
+              {loc.label}
+            </a>
           </li>
         ))
       }


### PR DESCRIPTION
- Set `trailingSlash` to "never" in `astro.config.ts`.
- Introduce `canonicalPathname` function in `src/lib/canonicalUrl.ts` to handle URL formatting.
- Update `Layout.astro` to include a canonical link element.
- Modify `index.astro` to use `getRelativeLocaleUrl` for locale links.